### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 |---|---|
 
 | Composer | [`minetro/latte-formatter`](https://packagist.org/packages/minetro/latte-formatter) |
-|---| --- |
+|---|---|
 | Version | ![](https://badgen.net/packagist/v/minetro/latte-formatter) |
 | PHP | ![](https://badgen.net/packagist/php/minetro/latte-formatter) |
-| License | ![](https://badgen.net/github/license/minetro/latte-formatter) |
+| License | ![](https://badgen.net/github/license/contributte/latte-formatter) |
 
 ## Usage
 
@@ -44,9 +44,9 @@ services:
 ```
 
 
-### Development
+## Development
 
-This package was maintain by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
@@ -55,4 +55,4 @@ This package was maintain by these authors.
 -----
 
 Consider to [support](https://contributte.org/partners.html) **contributte** development team.
-Also thank you for being used this package.
+Also thank you for using this package.


### PR DESCRIPTION
This PR fixes minor issues in the archived README to ensure it follows the archive template exactly:

## Changes
- Fixed license badge URL to reference `contributte/latte-formatter` instead of `minetro/latte-formatter`
- Fixed typo: "was maintain" → "was maintained"
- Fixed typo: "being used" → "using"
- Changed "### Development" to "## Development" for consistent heading level

The README already had the correct archive structure (deprecation badge, disclaimer, replacement package reference). These changes ensure full compliance with the archive template.